### PR TITLE
made caller server address for containers OS adaptive

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/HyperFaaS.iml
+++ b/.idea/HyperFaaS.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/HyperFaaS.iml" filepath="$PROJECT_DIR$/.idea/HyperFaaS.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/pkg/functionRuntimeInterface/functionRuntimeInterface.go
+++ b/pkg/functionRuntimeInterface/functionRuntimeInterface.go
@@ -3,6 +3,8 @@ package functionRuntimeInterface
 import (
 	"bufio"
 	"context"
+	"fmt"
+	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
 	"time"
@@ -34,9 +36,14 @@ type Function struct {
 }
 
 func New(timeout int) *Function {
+	address, ok := os.LookupEnv("CALLER_SERVER_ADDRESS")
+	if !ok {
+		log.Error().Msgf("Environment variable CALLER_SERVER_ADDRESS not found")
+	}
+
 	return &Function{
 		timeout:  timeout,
-		address:  "localhost:50052",
+		address:  fmt.Sprint(address, ":50052"),
 		request:  &Request{},
 		response: &Response{},
 		id:       getID(),


### PR DESCRIPTION
- Building images locally with buildAllImages.go sets an environment variable in the Dockerfiles called `CALLER_SERVER_ADDRESS`
- Now, functionRuntimeInterface uses this variable to correctly call the CallerServer that runs on the host.