### PR TITLE
Stream Resource Metrics from Workers to LeafNodes

### DIFF
--- a/cmd/hyperfaas-cli/main.go
+++ b/cmd/hyperfaas-cli/main.go
@@ -497,8 +497,8 @@ func GetWorkerMetrics(client workerpb.WorkerClient,
 		fmt.Printf("Error getting metrics: %v\n", err)
 		return err
 	}
-	fmt.Printf("CPU usage: %v%%\n", r.CpuPercentPercpus)
-	fmt.Printf("RAM usage: %v%%\n", r.UsedRamPercent)
+	fmt.Printf("CPU usage: %v%%\n", r.CpuUtilizationPercent)
+	fmt.Printf("RAM usage: %v%%\n", r.MemoryUtilizationPercent)
 	return nil
 }
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -44,7 +44,8 @@ type WorkerConfig struct {
 		FilePath string `env:"LOG_FILE"`
 	}
 	Stats struct {
-		UpdateBufferSize int64 `env:"UPDATE_BUFFER_SIZE"`
+		UpdateBufferSize int64         `env:"UPDATE_BUFFER_SIZE"`
+		MetricsInterval  time.Duration `env:"METRICS_INTERVAL"`
 	}
 }
 
@@ -61,6 +62,7 @@ func parseArgs() (wc WorkerConfig) {
 	flag.StringVar(&(wc.Log.FilePath), "log-file", "", "Log file path (defaults to stdout) (Env: LOG_FILE)")
 	flag.BoolVar(&(wc.Runtime.Containerized), "containerized", false, "Use socket to connect to Docker. (Env: RUNTIME_CONTAINERIZED)")
 	flag.Int64Var(&(wc.Stats.UpdateBufferSize), "update-buffer-size", 10000, "Update buffer size. (Env: UPDATE_BUFFER_SIZE)")
+	flag.DurationVar(&(wc.Stats.MetricsInterval), "metrics-interval", 1*time.Second, "Metrics sampling interval. (Env: METRICS_INTERVAL)")
 	flag.StringVar(&(wc.Runtime.ServiceName), "service-name", "worker", "Docker compose service name. (Env: RUNTIME_SERVICE_NAME)")
 	flag.StringVar(&(wc.Runtime.NetworkName), "network-name", "hyperfaas-network", "Docker network name for function containers. (Env: RUNTIME_NETWORK_NAME)")
 	flag.Var(&etcdEndpoints, "etcd-endpoint", "Etcd endpoint (can be specified multiple times). Defaults to localhost:2379")
@@ -123,7 +125,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	c := controller.NewController(runtime, statsManager, logger, wc.General.Address, metadataClient, readySignals)
+	c := controller.NewController(runtime, statsManager, logger, wc.General.Address, metadataClient, readySignals, wc.Runtime.Containerized, wc.Stats.MetricsInterval)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -46,6 +46,8 @@ type WorkerConfig struct {
 	Stats struct {
 		UpdateBufferSize int64         `env:"UPDATE_BUFFER_SIZE"`
 		MetricsInterval  time.Duration `env:"METRICS_INTERVAL"`
+		BudgetCPU        float64       `env:"WORKER_BUDGET_CPU"`
+		BudgetMemory     int64         `env:"WORKER_BUDGET_MEMORY"`
 	}
 }
 
@@ -63,6 +65,8 @@ func parseArgs() (wc WorkerConfig) {
 	flag.BoolVar(&(wc.Runtime.Containerized), "containerized", false, "Use socket to connect to Docker. (Env: RUNTIME_CONTAINERIZED)")
 	flag.Int64Var(&(wc.Stats.UpdateBufferSize), "update-buffer-size", 10000, "Update buffer size. (Env: UPDATE_BUFFER_SIZE)")
 	flag.DurationVar(&(wc.Stats.MetricsInterval), "metrics-interval", 1*time.Second, "Metrics sampling interval. (Env: METRICS_INTERVAL)")
+	flag.Float64Var(&(wc.Stats.BudgetCPU), "worker-budget-cpu", 2, "Worker CPU budget in cores. (Env: WORKER_BUDGET_CPU)")
+	flag.Int64Var(&(wc.Stats.BudgetMemory), "worker-budget-memory", 4*1024*1024*1024, "Worker memory budget in bytes. (Env: WORKER_BUDGET_MEMORY)")
 	flag.StringVar(&(wc.Runtime.ServiceName), "service-name", "worker", "Docker compose service name. (Env: RUNTIME_SERVICE_NAME)")
 	flag.StringVar(&(wc.Runtime.NetworkName), "network-name", "hyperfaas-network", "Docker network name for function containers. (Env: RUNTIME_NETWORK_NAME)")
 	flag.Var(&etcdEndpoints, "etcd-endpoint", "Etcd endpoint (can be specified multiple times). Defaults to localhost:2379")
@@ -125,7 +129,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	c := controller.NewController(runtime, statsManager, logger, wc.General.Address, metadataClient, readySignals, wc.Runtime.Containerized, wc.Stats.MetricsInterval)
+	c := controller.NewController(runtime, statsManager, logger, wc.General.Address, metadataClient, readySignals, wc.Runtime.Containerized, wc.Stats.MetricsInterval, wc.Stats.BudgetCPU, uint64(wc.Stats.BudgetMemory))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/leaf/api.go
+++ b/pkg/leaf/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/3s-rg-codes/HyperFaaS/pkg/leaf/metrics"
 	leafproxy "github.com/3s-rg-codes/HyperFaaS/pkg/leaf/proxy"
 	"github.com/3s-rg-codes/HyperFaaS/pkg/metadata"
+	mtrcs "github.com/3s-rg-codes/HyperFaaS/pkg/metrics"
 	"github.com/3s-rg-codes/HyperFaaS/proto/common"
 	leafpb "github.com/3s-rg-codes/HyperFaaS/proto/leaf"
 	workerpb "github.com/3s-rg-codes/HyperFaaS/proto/worker"
@@ -265,7 +266,7 @@ func (s *Server) handleWorkerMetrics(workerIdx int, update *workerpb.MetricsUpda
 	if update == nil || s.resourceMetricsCollector == nil {
 		return
 	}
-	metrics := metrics.ServerMetrics{
+	metrics := mtrcs.ResourceMetrics{
 		CPUUtilizationRaw:        update.CpuUtilizationRaw,
 		CPUUtilizationPercent:    update.CpuUtilizationPercent,
 		MemoryUtilizationRaw:     update.MemoryUtilizationRaw,

--- a/pkg/leaf/api.go
+++ b/pkg/leaf/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/3s-rg-codes/HyperFaaS/pkg/metadata"
 	"github.com/3s-rg-codes/HyperFaaS/proto/common"
 	leafpb "github.com/3s-rg-codes/HyperFaaS/proto/leaf"
+	workerpb "github.com/3s-rg-codes/HyperFaaS/proto/worker"
 )
 
 const STATE_STREAM_BUFFER = 10000
@@ -53,6 +54,9 @@ type Server struct {
 	// the direction of communication here is DataPlane / API (ScheduleCall) -> ControlPlane.
 	// Used for example in the scale from zero situation.
 	concurrencyReporter *metrics.ConcurrencyReporter
+
+	resourceMetricsStore     *metrics.ResourceMetricsStore
+	resourceMetricsCollector *metrics.ResourceMetricsCollector
 
 	// single centralised channel to read zero scale events from all functions.
 	// used for the State stream.
@@ -96,6 +100,9 @@ func NewServer(ctx context.Context, cfg config.Config, metadataClient metadata.C
 
 	cr := metrics.NewConcurrencyReporter(logger, metricChan, 1*time.Second)
 	go cr.Run(serverCtx)
+	resourceStore := metrics.NewResourceMetricsStore(len(workers))
+	resourceCollector := metrics.NewResourceMetricsCollector(resourceStore, logger, metrics.ResourceMetricsInterval)
+	go resourceCollector.Run(serverCtx)
 
 	dp := dataplane.NewDataPlane(logger, metadataClient, instanceChangesChan, cr)
 	go dp.Run(serverCtx)
@@ -104,16 +111,18 @@ func NewServer(ctx context.Context, cfg config.Config, metadataClient metadata.C
 	go cp.Run(serverCtx)
 
 	s := &Server{
-		cfg:                 cfg,
-		logger:              logger,
-		ctx:                 serverCtx,
-		cancel:              cancel,
-		nodeID:              uuid.NewString(),
-		metadataClient:      metadataClient,
-		dataPlane:           dp,
-		controlPlane:        cp,
-		concurrencyReporter: cr,
-		functionScaleEvents: functionScaleEvents,
+		cfg:                      cfg,
+		logger:                   logger,
+		ctx:                      serverCtx,
+		cancel:                   cancel,
+		nodeID:                   uuid.NewString(),
+		metadataClient:           metadataClient,
+		dataPlane:                dp,
+		controlPlane:             cp,
+		concurrencyReporter:      cr,
+		resourceMetricsStore:     resourceStore,
+		resourceMetricsCollector: resourceCollector,
+		functionScaleEvents:      functionScaleEvents,
 	}
 
 	s.workers = workers
@@ -125,6 +134,7 @@ func NewServer(ctx context.Context, cfg config.Config, metadataClient metadata.C
 
 	for _, w := range s.workers {
 		w.StartStatusStream(s.nodeID, cfg.StatusBackoff, s.handleWorkerStatus)
+		w.StartMetricsStream(s.nodeID, cfg.StatusBackoff, s.handleWorkerMetrics)
 	}
 
 	return s, nil
@@ -249,6 +259,19 @@ func (s *Server) handleWorkerStatus(workerIdx int, update *dataplane.WorkerStatu
 		return
 	}
 	s.controlPlane.HandleWorkerEvent(workerIdx, update)
+}
+
+func (s *Server) handleWorkerMetrics(workerIdx int, update *workerpb.MetricsUpdate) {
+	if update == nil || s.resourceMetricsCollector == nil {
+		return
+	}
+	metrics := metrics.ServerMetrics{
+		CPUUtilizationRaw:        update.CpuUtilizationRaw,
+		CPUUtilizationPercent:    update.CpuUtilizationPercent,
+		MemoryUtilizationRaw:     update.MemoryUtilizationRaw,
+		MemoryUtilizationPercent: update.MemoryUtilizationPercent,
+	}
+	s.resourceMetricsCollector.Add(workerIdx, metrics)
 }
 
 // ProxyBackendResolver exposes a BackendResolver that can be used by the gRPC proxy listener.

--- a/pkg/leaf/api_test.go
+++ b/pkg/leaf/api_test.go
@@ -160,6 +160,9 @@ func newTestServer(ctx context.Context, cfg config.Config, metadataClient metada
 
 	cr := metrics.NewConcurrencyReporter(logger, metricChan, 1*time.Second)
 	go cr.Run(serverCtx)
+	resourceStore := metrics.NewResourceMetricsStore(len(workers))
+	resourceCollector := metrics.NewResourceMetricsCollector(resourceStore, logger, metrics.ResourceMetricsInterval)
+	go resourceCollector.Run(serverCtx)
 
 	dp := dataplane.NewDataPlane(logger, metadataClient, instanceChangesChan, cr)
 	go dp.Run(serverCtx)
@@ -168,16 +171,18 @@ func newTestServer(ctx context.Context, cfg config.Config, metadataClient metada
 	go cp.Run(serverCtx)
 
 	s := &Server{
-		cfg:                 cfg,
-		logger:              logger,
-		ctx:                 serverCtx,
-		cancel:              cancel,
-		nodeID:              uuid.NewString(),
-		metadataClient:      metadataClient,
-		dataPlane:           dp,
-		controlPlane:        cp,
-		concurrencyReporter: cr,
-		functionScaleEvents: functionScaleEvents,
+		cfg:                      cfg,
+		logger:                   logger,
+		ctx:                      serverCtx,
+		cancel:                   cancel,
+		nodeID:                   uuid.NewString(),
+		metadataClient:           metadataClient,
+		dataPlane:                dp,
+		controlPlane:             cp,
+		concurrencyReporter:      cr,
+		resourceMetricsStore:     resourceStore,
+		resourceMetricsCollector: resourceCollector,
+		functionScaleEvents:      functionScaleEvents,
 	}
 
 	s.workers = workers
@@ -189,6 +194,7 @@ func newTestServer(ctx context.Context, cfg config.Config, metadataClient metada
 
 	for _, w := range s.workers {
 		w.StartStatusStream(s.nodeID, cfg.StatusBackoff, s.handleWorkerStatus)
+		w.StartMetricsStream(s.nodeID, cfg.StatusBackoff, s.handleWorkerMetrics)
 	}
 
 	return s, nil

--- a/pkg/leaf/dataplane/worker_client.go
+++ b/pkg/leaf/dataplane/worker_client.go
@@ -47,6 +47,8 @@ type WorkerClient struct {
 
 	// to make sure that we only start one status stream per worker
 	statusOnce sync.Once
+	// to make sure that we only start one metrics stream per worker
+	metricsOnce sync.Once
 }
 
 func NewWorkerClient(ctx context.Context, idx int, addr string, cfg config.Config, logger *slog.Logger) (*WorkerClient, error) {
@@ -111,6 +113,13 @@ func (w *WorkerClient) StartStatusStream(nodeID string, backoff time.Duration, c
 	})
 }
 
+// startMetricsStream starts the metrics stream in a goroutine if it hasn't been started yet.
+func (w *WorkerClient) StartMetricsStream(nodeID string, backoff time.Duration, cb func(int, *workerpb.MetricsUpdate)) {
+	w.metricsOnce.Do(func() {
+		go w.runMetricsStream(nodeID, backoff, cb)
+	})
+}
+
 // runStatusStream reads from the workers status stream in a loop, and calls the callback function with the status events.
 func (w *WorkerClient) runStatusStream(nodeID string, backoff time.Duration, cb func(int, *WorkerStatusEvent)) {
 	if backoff <= 0 {
@@ -161,6 +170,55 @@ func (w *WorkerClient) runStatusStream(nodeID string, backoff time.Duration, cb 
 	}
 }
 
+func (w *WorkerClient) runMetricsStream(nodeID string, backoff time.Duration, cb func(int, *workerpb.MetricsUpdate)) {
+	if backoff <= 0 {
+		backoff = time.Second
+	}
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		default:
+		}
+
+		streamCtx, cancel := context.WithCancel(w.ctx)
+		stream, err := w.client.MetricsStream(streamCtx, &workerpb.MetricsRequest{NodeId: nodeID})
+		if err != nil {
+			cancel()
+			if status.Code(err) != codes.Canceled {
+				w.logger.Warn("worker metrics stream dial failed", "error", err)
+			}
+			select {
+			case <-time.After(backoff):
+			case <-w.ctx.Done():
+				return
+			}
+			continue
+		}
+
+		for {
+			update, recvErr := stream.Recv()
+			if recvErr != nil {
+				cancel()
+				if w.ctx.Err() != nil {
+					return
+				}
+				w.logger.Debug("worker metrics stream ended", "error", recvErr)
+				break
+			}
+			cb(w.index, update)
+		}
+
+		cancel()
+
+		select {
+		case <-time.After(backoff):
+		case <-w.ctx.Done():
+			return
+		}
+	}
+}
+
 type WorkerStatusEvent struct {
 	FunctionId string
 	InstanceId string
@@ -190,8 +248,10 @@ func newMockWorkerClient() workerpb.WorkerClient {
 // Metrics implements worker.WorkerClient.
 func (m mockWorkerClient) Metrics(ctx context.Context, in *workerpb.MetricsRequest, opts ...grpc.CallOption) (*workerpb.MetricsUpdate, error) {
 	return &workerpb.MetricsUpdate{
-		UsedRamPercent:    0,
-		CpuPercentPercpus: []float64{0},
+		CpuUtilizationRaw:        0,
+		CpuUtilizationPercent:    0,
+		MemoryUtilizationRaw:     0,
+		MemoryUtilizationPercent: 0,
 	}, nil
 }
 
@@ -217,6 +277,11 @@ func (m mockWorkerClient) Start(ctx context.Context, in *workerpb.StartRequest, 
 // Status implements worker.WorkerClient.
 func (m mockWorkerClient) Status(ctx context.Context, in *workerpb.StatusRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[workerpb.StatusUpdate], error) {
 	return &mockStatusStream{ctx: ctx}, nil
+}
+
+// MetricsStream implements worker.WorkerClient.
+func (m mockWorkerClient) MetricsStream(ctx context.Context, in *workerpb.MetricsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[workerpb.MetricsUpdate], error) {
+	return &mockMetricsStream{ctx: ctx}, nil
 }
 
 // Stop implements worker.WorkerClient.
@@ -257,5 +322,37 @@ func (m *mockStatusStream) RecvMsg(interface{}) error {
 }
 
 func (m *mockStatusStream) Recv() (*workerpb.StatusUpdate, error) {
+	return nil, io.EOF
+}
+
+type mockMetricsStream struct {
+	ctx context.Context
+}
+
+func (m *mockMetricsStream) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (m *mockMetricsStream) Trailer() metadata.MD {
+	return nil
+}
+
+func (m *mockMetricsStream) CloseSend() error {
+	return nil
+}
+
+func (m *mockMetricsStream) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockMetricsStream) SendMsg(interface{}) error {
+	return nil
+}
+
+func (m *mockMetricsStream) RecvMsg(interface{}) error {
+	return io.EOF
+}
+
+func (m *mockMetricsStream) Recv() (*workerpb.MetricsUpdate, error) {
 	return nil, io.EOF
 }

--- a/pkg/leaf/metrics/resource_metrics.go
+++ b/pkg/leaf/metrics/resource_metrics.go
@@ -6,18 +6,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-)
 
-type ServerMetrics struct {
-	// number of nanoseconds the CPU was used for the last interval.
-	CPUUtilizationRaw float64
-	// percentage of total system CPU used for the last interval.
-	CPUUtilizationPercent float32
-	// raw bytes of memory used for the last interval.
-	MemoryUtilizationRaw float64
-	// percentage of total system memory used for the last interval.
-	MemoryUtilizationPercent float32
-}
+	mtrcs "github.com/3s-rg-codes/HyperFaaS/pkg/metrics"
+)
 
 const (
 	ResourceMetricsWindow   = 60
@@ -27,13 +18,13 @@ const (
 
 type BestWorkerSnapshot struct {
 	Index   int
-	Metrics ServerMetrics
+	Metrics mtrcs.ResourceMetrics
 	Ok      bool
 }
 
 type ResourceMetricEvent struct {
 	WorkerIdx int
-	Metrics   ServerMetrics
+	Metrics   mtrcs.ResourceMetrics
 }
 
 type ResourceMetricsStore struct {
@@ -60,7 +51,7 @@ func (s *ResourceMetricsStore) WorkerCount() int {
 	return len(s.workers)
 }
 
-func (s *ResourceMetricsStore) Update(workerIdx int, metrics ServerMetrics) {
+func (s *ResourceMetricsStore) Update(workerIdx int, metrics mtrcs.ResourceMetrics) {
 	if workerIdx < 0 || workerIdx >= len(s.workers) {
 		return
 	}
@@ -71,19 +62,19 @@ func (s *ResourceMetricsStore) Update(workerIdx int, metrics ServerMetrics) {
 	s.latest[workerIdx].Store(metrics)
 }
 
-func (s *ResourceMetricsStore) Latest(workerIdx int) (ServerMetrics, bool) {
+func (s *ResourceMetricsStore) Latest(workerIdx int) (mtrcs.ResourceMetrics, bool) {
 	if workerIdx < 0 || workerIdx >= len(s.latest) {
-		return ServerMetrics{}, false
+		return mtrcs.ResourceMetrics{}, false
 	}
 	value := s.latest[workerIdx].Load()
 	if value == nil {
-		return ServerMetrics{}, false
+		return mtrcs.ResourceMetrics{}, false
 	}
-	metrics, ok := value.(ServerMetrics)
+	metrics, ok := value.(mtrcs.ResourceMetrics)
 	return metrics, ok
 }
 
-func (s *ResourceMetricsStore) History(workerIdx int, dst []ServerMetrics) int {
+func (s *ResourceMetricsStore) History(workerIdx int, dst []mtrcs.ResourceMetrics) int {
 	if workerIdx < 0 || workerIdx >= len(s.workers) {
 		return 0
 	}
@@ -116,7 +107,7 @@ type ResourceMetricsCollector struct {
 
 type pendingMetric struct {
 	set     bool
-	metrics ServerMetrics
+	metrics mtrcs.ResourceMetrics
 }
 
 func NewResourceMetricsCollector(store *ResourceMetricsStore, logger *slog.Logger, interval time.Duration) *ResourceMetricsCollector {
@@ -134,7 +125,7 @@ func NewResourceMetricsCollector(store *ResourceMetricsStore, logger *slog.Logge
 	}
 }
 
-func (c *ResourceMetricsCollector) Add(workerIdx int, metrics ServerMetrics) {
+func (c *ResourceMetricsCollector) Add(workerIdx int, metrics mtrcs.ResourceMetrics) {
 	select {
 	case c.updates <- ResourceMetricEvent{WorkerIdx: workerIdx, Metrics: metrics}:
 	default:
@@ -179,7 +170,7 @@ func (c *ResourceMetricsCollector) flushPending(pending []pendingMetric) {
 			continue
 		}
 		if !best.Ok || metrics.CPUUtilizationPercent < best.Metrics.CPUUtilizationPercent {
-			c.logger.Info("new best worker", "worker", idx, "cpu_percent", metrics.CPUUtilizationPercent, "memory_percent", metrics.MemoryUtilizationPercent)
+			//c.logger.Info("new best worker", "worker", idx, "cpu_percent", metrics.CPUUtilizationPercent, "memory_percent", metrics.MemoryUtilizationPercent)
 			best = BestWorkerSnapshot{Index: idx, Metrics: metrics, Ok: true}
 		}
 	}
@@ -197,7 +188,7 @@ type workerMetricsRing struct {
 	memPct [ResourceMetricsWindow]float32
 }
 
-func (w *workerMetricsRing) append(metrics ServerMetrics) {
+func (w *workerMetricsRing) append(metrics mtrcs.ResourceMetrics) {
 	w.cpuRaw[w.head] = metrics.CPUUtilizationRaw
 	w.cpuPct[w.head] = metrics.CPUUtilizationPercent
 	w.memRaw[w.head] = metrics.MemoryUtilizationRaw
@@ -208,7 +199,7 @@ func (w *workerMetricsRing) append(metrics ServerMetrics) {
 	}
 }
 
-func (w *workerMetricsRing) history(dst []ServerMetrics) int {
+func (w *workerMetricsRing) history(dst []mtrcs.ResourceMetrics) int {
 	if w.count == 0 || len(dst) == 0 {
 		return 0
 	}
@@ -222,7 +213,7 @@ func (w *workerMetricsRing) history(dst []ServerMetrics) int {
 	}
 	for i := 0; i < n; i++ {
 		idx := (start + i) % ResourceMetricsWindow
-		dst[i] = ServerMetrics{
+		dst[i] = mtrcs.ResourceMetrics{
 			CPUUtilizationRaw:        w.cpuRaw[idx],
 			CPUUtilizationPercent:    w.cpuPct[idx],
 			MemoryUtilizationRaw:     w.memRaw[idx],

--- a/pkg/leaf/metrics/resource_metrics.go
+++ b/pkg/leaf/metrics/resource_metrics.go
@@ -170,7 +170,7 @@ func (c *ResourceMetricsCollector) flushPending(pending []pendingMetric) {
 			continue
 		}
 		if !best.Ok || metrics.CPUUtilizationPercent < best.Metrics.CPUUtilizationPercent {
-			//c.logger.Info("new best worker", "worker", idx, "cpu_percent", metrics.CPUUtilizationPercent, "memory_percent", metrics.MemoryUtilizationPercent)
+			// c.logger.Info("new best worker", "worker", idx, "cpu_percent", metrics.CPUUtilizationPercent, "memory_percent", metrics.MemoryUtilizationPercent)
 			best = BestWorkerSnapshot{Index: idx, Metrics: metrics, Ok: true}
 		}
 	}

--- a/pkg/leaf/metrics/resource_metrics.go
+++ b/pkg/leaf/metrics/resource_metrics.go
@@ -1,0 +1,233 @@
+package metrics
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type ServerMetrics struct {
+	// number of nanoseconds the CPU was used for the last interval.
+	CPUUtilizationRaw float64
+	// percentage of total system CPU used for the last interval.
+	CPUUtilizationPercent float32
+	// raw bytes of memory used for the last interval.
+	MemoryUtilizationRaw float64
+	// percentage of total system memory used for the last interval.
+	MemoryUtilizationPercent float32
+}
+
+const (
+	ResourceMetricsWindow   = 60
+	ResourceMetricsBuffer   = 10000
+	ResourceMetricsInterval = time.Second
+)
+
+type BestWorkerSnapshot struct {
+	Index   int
+	Metrics ServerMetrics
+	Ok      bool
+}
+
+type ResourceMetricEvent struct {
+	WorkerIdx int
+	Metrics   ServerMetrics
+}
+
+type ResourceMetricsStore struct {
+	workers []workerMetricsRing
+	locks   []sync.RWMutex
+	latest  []atomic.Value
+	best    atomic.Value
+}
+
+// Latest reads are lock-free and can be slightly stale while a tick is in-flight.
+func NewResourceMetricsStore(workerCount int) *ResourceMetricsStore {
+	if workerCount < 0 {
+		workerCount = 0
+	}
+	store := &ResourceMetricsStore{
+		workers: make([]workerMetricsRing, workerCount),
+		locks:   make([]sync.RWMutex, workerCount),
+		latest:  make([]atomic.Value, workerCount),
+	}
+	return store
+}
+
+func (s *ResourceMetricsStore) WorkerCount() int {
+	return len(s.workers)
+}
+
+func (s *ResourceMetricsStore) Update(workerIdx int, metrics ServerMetrics) {
+	if workerIdx < 0 || workerIdx >= len(s.workers) {
+		return
+	}
+	lock := &s.locks[workerIdx]
+	lock.Lock()
+	s.workers[workerIdx].append(metrics)
+	lock.Unlock()
+	s.latest[workerIdx].Store(metrics)
+}
+
+func (s *ResourceMetricsStore) Latest(workerIdx int) (ServerMetrics, bool) {
+	if workerIdx < 0 || workerIdx >= len(s.latest) {
+		return ServerMetrics{}, false
+	}
+	value := s.latest[workerIdx].Load()
+	if value == nil {
+		return ServerMetrics{}, false
+	}
+	metrics, ok := value.(ServerMetrics)
+	return metrics, ok
+}
+
+func (s *ResourceMetricsStore) History(workerIdx int, dst []ServerMetrics) int {
+	if workerIdx < 0 || workerIdx >= len(s.workers) {
+		return 0
+	}
+	lock := &s.locks[workerIdx]
+	lock.RLock()
+	n := s.workers[workerIdx].history(dst)
+	lock.RUnlock()
+	return n
+}
+
+func (s *ResourceMetricsStore) SetBest(snapshot BestWorkerSnapshot) {
+	s.best.Store(snapshot)
+}
+
+func (s *ResourceMetricsStore) BestWorker() (BestWorkerSnapshot, bool) {
+	value := s.best.Load()
+	if value == nil {
+		return BestWorkerSnapshot{}, false
+	}
+	snapshot, ok := value.(BestWorkerSnapshot)
+	return snapshot, ok
+}
+
+type ResourceMetricsCollector struct {
+	store    *ResourceMetricsStore
+	updates  chan ResourceMetricEvent
+	interval time.Duration
+	logger   *slog.Logger
+}
+
+type pendingMetric struct {
+	set     bool
+	metrics ServerMetrics
+}
+
+func NewResourceMetricsCollector(store *ResourceMetricsStore, logger *slog.Logger, interval time.Duration) *ResourceMetricsCollector {
+	if interval <= 0 {
+		interval = ResourceMetricsInterval
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ResourceMetricsCollector{
+		store:    store,
+		updates:  make(chan ResourceMetricEvent, ResourceMetricsBuffer),
+		interval: interval,
+		logger:   logger.With("component", "resource_metrics"),
+	}
+}
+
+func (c *ResourceMetricsCollector) Add(workerIdx int, metrics ServerMetrics) {
+	select {
+	case c.updates <- ResourceMetricEvent{WorkerIdx: workerIdx, Metrics: metrics}:
+	default:
+		c.logger.Warn("resource metrics buffer full", "worker", workerIdx)
+	}
+}
+
+func (c *ResourceMetricsCollector) Run(ctx context.Context) {
+	if c.store == nil {
+		return
+	}
+	pending := make([]pendingMetric, c.store.WorkerCount())
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-c.updates:
+			if ev.WorkerIdx < 0 || ev.WorkerIdx >= len(pending) {
+				continue
+			}
+			pending[ev.WorkerIdx] = pendingMetric{set: true, metrics: ev.Metrics}
+		case <-ticker.C:
+			c.flushPending(pending)
+		}
+	}
+}
+
+func (c *ResourceMetricsCollector) flushPending(pending []pendingMetric) {
+	for idx := range pending {
+		if pending[idx].set {
+			c.store.Update(idx, pending[idx].metrics)
+			pending[idx] = pendingMetric{}
+		}
+	}
+
+	best := BestWorkerSnapshot{}
+	for idx := 0; idx < c.store.WorkerCount(); idx++ {
+		metrics, ok := c.store.Latest(idx)
+		if !ok {
+			continue
+		}
+		if !best.Ok || metrics.CPUUtilizationPercent < best.Metrics.CPUUtilizationPercent {
+			c.logger.Info("new best worker", "worker", idx, "cpu_percent", metrics.CPUUtilizationPercent, "memory_percent", metrics.MemoryUtilizationPercent)
+			best = BestWorkerSnapshot{Index: idx, Metrics: metrics, Ok: true}
+		}
+	}
+	if best.Ok {
+		c.store.SetBest(best)
+	}
+}
+
+type workerMetricsRing struct {
+	head   int
+	count  int
+	cpuRaw [ResourceMetricsWindow]float64
+	cpuPct [ResourceMetricsWindow]float32
+	memRaw [ResourceMetricsWindow]float64
+	memPct [ResourceMetricsWindow]float32
+}
+
+func (w *workerMetricsRing) append(metrics ServerMetrics) {
+	w.cpuRaw[w.head] = metrics.CPUUtilizationRaw
+	w.cpuPct[w.head] = metrics.CPUUtilizationPercent
+	w.memRaw[w.head] = metrics.MemoryUtilizationRaw
+	w.memPct[w.head] = metrics.MemoryUtilizationPercent
+	w.head = (w.head + 1) % ResourceMetricsWindow
+	if w.count < ResourceMetricsWindow {
+		w.count++
+	}
+}
+
+func (w *workerMetricsRing) history(dst []ServerMetrics) int {
+	if w.count == 0 || len(dst) == 0 {
+		return 0
+	}
+	n := w.count
+	if len(dst) < n {
+		n = len(dst)
+	}
+	start := w.head - w.count
+	if start < 0 {
+		start += ResourceMetricsWindow
+	}
+	for i := 0; i < n; i++ {
+		idx := (start + i) % ResourceMetricsWindow
+		dst[i] = ServerMetrics{
+			CPUUtilizationRaw:        w.cpuRaw[idx],
+			CPUUtilizationPercent:    w.cpuPct[idx],
+			MemoryUtilizationRaw:     w.memRaw[idx],
+			MemoryUtilizationPercent: w.memPct[idx],
+		}
+	}
+	return n
+}

--- a/pkg/leaf/metrics/resource_metrics_test.go
+++ b/pkg/leaf/metrics/resource_metrics_test.go
@@ -8,15 +8,17 @@ import (
 	"log/slog"
 	"testing"
 	"time"
+
+	mtrcs "github.com/3s-rg-codes/HyperFaaS/pkg/metrics"
 )
 
 func TestResourceMetricsHistoryOrder(t *testing.T) {
 	store := NewResourceMetricsStore(1)
-	store.Update(0, ServerMetrics{CPUUtilizationPercent: 1})
-	store.Update(0, ServerMetrics{CPUUtilizationPercent: 2})
-	store.Update(0, ServerMetrics{CPUUtilizationPercent: 3})
+	store.Update(0, mtrcs.ResourceMetrics{CPUUtilizationPercent: 1})
+	store.Update(0, mtrcs.ResourceMetrics{CPUUtilizationPercent: 2})
+	store.Update(0, mtrcs.ResourceMetrics{CPUUtilizationPercent: 3})
 
-	buf := make([]ServerMetrics, 3)
+	buf := make([]mtrcs.ResourceMetrics, 3)
 	n := store.History(0, buf)
 	if n != 3 {
 		t.Fatalf("unexpected history count: %d", n)
@@ -40,8 +42,8 @@ func TestResourceMetricsCollectorUpdatesStore(t *testing.T) {
 	defer cancel()
 	go collector.Run(ctx)
 
-	collector.Add(0, ServerMetrics{CPUUtilizationPercent: 50})
-	collector.Add(1, ServerMetrics{CPUUtilizationPercent: 10})
+	collector.Add(0, mtrcs.ResourceMetrics{CPUUtilizationPercent: 50})
+	collector.Add(1, mtrcs.ResourceMetrics{CPUUtilizationPercent: 10})
 
 	time.Sleep(20 * time.Millisecond)
 

--- a/pkg/leaf/metrics/resource_metrics_test.go
+++ b/pkg/leaf/metrics/resource_metrics_test.go
@@ -1,0 +1,66 @@
+//go:build unit
+
+package metrics
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestResourceMetricsHistoryOrder(t *testing.T) {
+	store := NewResourceMetricsStore(1)
+	store.Update(0, ServerMetrics{CPUUtilizationPercent: 1})
+	store.Update(0, ServerMetrics{CPUUtilizationPercent: 2})
+	store.Update(0, ServerMetrics{CPUUtilizationPercent: 3})
+
+	buf := make([]ServerMetrics, 3)
+	n := store.History(0, buf)
+	if n != 3 {
+		t.Fatalf("unexpected history count: %d", n)
+	}
+	if buf[0].CPUUtilizationPercent != 1 {
+		t.Fatalf("unexpected metric[0]: %v", buf[0].CPUUtilizationPercent)
+	}
+	if buf[1].CPUUtilizationPercent != 2 {
+		t.Fatalf("unexpected metric[1]: %v", buf[1].CPUUtilizationPercent)
+	}
+	if buf[2].CPUUtilizationPercent != 3 {
+		t.Fatalf("unexpected metric[2]: %v", buf[2].CPUUtilizationPercent)
+	}
+}
+
+func TestResourceMetricsCollectorUpdatesStore(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := NewResourceMetricsStore(2)
+	collector := NewResourceMetricsCollector(store, logger, 10*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go collector.Run(ctx)
+
+	collector.Add(0, ServerMetrics{CPUUtilizationPercent: 50})
+	collector.Add(1, ServerMetrics{CPUUtilizationPercent: 10})
+
+	time.Sleep(20 * time.Millisecond)
+
+	metrics, ok := store.Latest(1)
+	if !ok {
+		t.Fatal("expected latest metrics")
+	}
+	if metrics.CPUUtilizationPercent != 10 {
+		t.Fatalf("unexpected cpu percent: %v", metrics.CPUUtilizationPercent)
+	}
+
+	best, ok := store.BestWorker()
+	if !ok {
+		t.Fatal("expected best worker")
+	}
+	if !best.Ok {
+		t.Fatal("expected best worker snapshot")
+	}
+	if best.Index != 1 {
+		t.Fatalf("unexpected best worker: %d", best.Index)
+	}
+}

--- a/pkg/metrics/resource_metrics.go
+++ b/pkg/metrics/resource_metrics.go
@@ -1,0 +1,12 @@
+package metrics
+
+type ResourceMetrics struct {
+	// number of nanoseconds the CPU was used for the last interval.
+	CPUUtilizationRaw float64
+	// percentage of total system CPU used for the last interval.
+	CPUUtilizationPercent float32
+	// raw bytes of memory used for the last interval.
+	MemoryUtilizationRaw float64
+	// percentage of total system memory used for the last interval.
+	MemoryUtilizationPercent float32
+}

--- a/pkg/worker/containerRuntime/containerRuntime.go
+++ b/pkg/worker/containerRuntime/containerRuntime.go
@@ -2,7 +2,6 @@ package containerRuntime
 
 import (
 	"context"
-	"io"
 
 	"github.com/3s-rg-codes/HyperFaaS/proto/common"
 )
@@ -12,6 +11,11 @@ type Container struct {
 	InternalIP string
 	ExternalIP string
 	Name       string
+}
+
+type ContainerStats struct {
+	CPUUsageTotal uint64
+	MemoryUsage   uint64
 }
 
 // ContainerRuntime is an interface for starting and stopping containers.
@@ -31,7 +35,7 @@ type ContainerRuntime interface {
 	ContainerExists(ctx context.Context, instanceID string) bool
 
 	// ContainerStats returns the stats for the container with the provided id
-	ContainerStats(ctx context.Context, containerID string) io.ReadCloser
+	ContainerStats(ctx context.Context, containerID string) (<-chan ContainerStats, <-chan error)
 }
 
 type ContainerEvent int

--- a/pkg/worker/containerRuntime/docker/dockerRuntime.go
+++ b/pkg/worker/containerRuntime/docker/dockerRuntime.go
@@ -2,6 +2,7 @@ package dockerRuntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -247,9 +248,47 @@ func (d *DockerRuntime) ContainerExists(ctx context.Context, instanceID string) 
 	return false
 }
 
-func (d *DockerRuntime) ContainerStats(ctx context.Context, containerID string) io.ReadCloser { // TODO: we need to find a return type that is compatible with all container runtimes and makes sense
-	st, _ := d.Cli.ContainerStats(ctx, containerID, false)
-	return st.Body
+func (d *DockerRuntime) ContainerStats(ctx context.Context, containerID string) (<-chan cr.ContainerStats, <-chan error) {
+	statsCh := make(chan cr.ContainerStats)
+	errCh := make(chan error, 1)
+
+	resp, err := d.Cli.ContainerStats(ctx, containerID, true)
+	if err != nil {
+		errCh <- err
+		close(statsCh)
+		close(errCh)
+		return statsCh, errCh
+	}
+
+	go func() {
+		defer resp.Body.Close()
+		defer close(statsCh)
+		defer close(errCh)
+
+		decoder := json.NewDecoder(resp.Body)
+		for {
+			var payload container.StatsResponse
+			if err := decoder.Decode(&payload); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				errCh <- err
+				return
+			}
+
+			stat := cr.ContainerStats{
+				CPUUsageTotal: payload.CPUStats.CPUUsage.TotalUsage,
+				MemoryUsage:   payload.MemoryStats.Usage,
+			}
+			select {
+			case statsCh <- stat:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return statsCh, errCh
 }
 
 func (d *DockerRuntime) createContainerConfig(imageTag string, functionID string) *container.Config {

--- a/pkg/worker/containerRuntime/docker/dockerRuntime.go
+++ b/pkg/worker/containerRuntime/docker/dockerRuntime.go
@@ -261,7 +261,11 @@ func (d *DockerRuntime) ContainerStats(ctx context.Context, containerID string) 
 	}
 
 	go func() {
-		defer resp.Body.Close()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				return
+			}
+		}()
 		defer close(statsCh)
 		defer close(errCh)
 

--- a/pkg/worker/containerRuntime/docker/dockerRuntime_integration_test.go
+++ b/pkg/worker/containerRuntime/docker/dockerRuntime_integration_test.go
@@ -71,7 +71,9 @@ func startWorkerServer() (chan bool, context.CancelFunc) {
 				logger,
 				WORKER_LISTENER_ADDRESS,
 				fakeMetadata{},
-				controller.NewReadySignals(false))
+				controller.NewReadySignals(false),
+				false,
+				time.Second)
 			c.StartServer(ctx)
 		})
 	}()

--- a/pkg/worker/containerRuntime/docker/dockerRuntime_integration_test.go
+++ b/pkg/worker/containerRuntime/docker/dockerRuntime_integration_test.go
@@ -73,7 +73,9 @@ func startWorkerServer() (chan bool, context.CancelFunc) {
 				fakeMetadata{},
 				controller.NewReadySignals(false),
 				false,
-				time.Second)
+				time.Second,
+				2,
+				4*1024*1024*1024)
 			c.StartServer(ctx)
 		})
 	}()

--- a/pkg/worker/containerRuntime/mock/mockRuntime.go
+++ b/pkg/worker/containerRuntime/mock/mockRuntime.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -42,7 +43,7 @@ func (m *MockRuntime) ContainerStats(ctx context.Context, containerID string) (<
 	statsCh := make(chan cr.ContainerStats)
 	errCh := make(chan error, 1)
 	close(statsCh)
-	errCh <- fmt.Errorf("container stats not supported in mock runtime")
+	errCh <- errors.New("container stats not supported in mock runtime")
 	close(errCh)
 	return statsCh, errCh
 }

--- a/pkg/worker/containerRuntime/mock/mockRuntime.go
+++ b/pkg/worker/containerRuntime/mock/mockRuntime.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"sync"
 
@@ -39,10 +38,13 @@ func (m *MockRuntime) ContainerExists(ctx context.Context, instanceID string) bo
 }
 
 // ContainerStats doesnt make sense for mock runtime
-func (m *MockRuntime) ContainerStats(ctx context.Context, containerID string) io.ReadCloser {
-	// maybe doesn't make sense for mock runtime ..?
-	// TODO
-	panic("not implemented")
+func (m *MockRuntime) ContainerStats(ctx context.Context, containerID string) (<-chan cr.ContainerStats, <-chan error) {
+	statsCh := make(chan cr.ContainerStats)
+	errCh := make(chan error, 1)
+	close(statsCh)
+	errCh <- fmt.Errorf("container stats not supported in mock runtime")
+	close(errCh)
+	return statsCh, errCh
 }
 
 // MonitorContainer implements containerRuntime.ContainerRuntime.

--- a/pkg/worker/controller/controller.go
+++ b/pkg/worker/controller/controller.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/3s-rg-codes/HyperFaaS/pkg/metadata"
+	sharedmetrics "github.com/3s-rg-codes/HyperFaaS/pkg/metrics"
 	cr "github.com/3s-rg-codes/HyperFaaS/pkg/worker/containerRuntime"
 	"github.com/3s-rg-codes/HyperFaaS/pkg/worker/stats"
 	workerPB "github.com/3s-rg-codes/HyperFaaS/proto/worker"
@@ -25,14 +26,16 @@ import (
 
 type Controller struct {
 	workerPB.UnimplementedWorkerServer
-	runtime         cr.ContainerRuntime
-	StatsManager    *stats.StatsManager
-	metricsSampler  *stats.MetricsSampler
-	metricsInterval time.Duration
-	logger          *slog.Logger
-	address         string
-	metadataClient  metadataProvider
-	readySignals    *ReadySignals
+	runtime           cr.ContainerRuntime
+	StatsManager      *stats.StatsManager
+	metricsSampler    *stats.MetricsSampler
+	metricsInterval   time.Duration
+	resourceManager   *ResourceManager
+	workerContainerID string
+	logger            *slog.Logger
+	address           string
+	metadataClient    metadataProvider
+	readySignals      *ReadySignals
 }
 type metadataProvider interface {
 	GetFunction(ctx context.Context, id string) (*metadata.FunctionMetadata, error)
@@ -67,13 +70,15 @@ func (s *Controller) Start(ctx context.Context, req *workerPB.StartRequest) (*wo
 	if len(container.Id) > 12 {
 		shortID = container.Id[:12]
 	}
-	// Add the instance to the map to wait for the ready signal
-	s.readySignals.AddInstance(shortID)
-
 	if err != nil {
 		s.StatsManager.Enqueue(stats.Event().Function(req.FunctionId).Container(shortID).Start().Failed())
 		s.logger.Error("Failed to start container", "error", err)
 		return nil, err
+	}
+
+	s.readySignals.AddInstance(shortID)
+	if s.resourceManager != nil {
+		s.resourceManager.AddContainer(container.Id)
 	}
 	// Container has been requested; we actually dont know if its running or not
 	s.StatsManager.Enqueue(stats.Event().Function(req.FunctionId).Container(shortID).Start().Success())
@@ -99,6 +104,9 @@ func (s *Controller) SignalReady(ctx context.Context, req *workerPB.SignalReadyR
 }
 
 func (s *Controller) Stop(ctx context.Context, req *workerPB.StopRequest) (*workerPB.StopResponse, error) {
+	if s.resourceManager != nil {
+		s.resourceManager.RemoveContainer(req.InstanceId)
+	}
 	err := s.runtime.Stop(ctx, req.InstanceId)
 	if err != nil {
 		s.logger.Error("Failed to stop container", "instance ID", req.InstanceId, "error", err)
@@ -162,22 +170,13 @@ func (s *Controller) Status(req *workerPB.StatusRequest, stream workerPB.Worker_
 }
 
 func (s *Controller) Metrics(ctx context.Context, req *workerPB.MetricsRequest) (*workerPB.MetricsUpdate, error) {
-	metrics, ok := s.metricsSampler.Latest()
-	if !ok {
-		var err error
-		metrics, err = s.metricsSampler.Sample()
-		if err != nil {
-			s.logger.Error("failed to sample metrics", "error", err)
-			return nil, status.Errorf(codes.Unavailable, "failed to sample metrics: %v", err)
-		}
+	metrics, err := s.getMetricsSnapshot()
+	if err != nil {
+		s.logger.Error("failed to sample metrics", "error", err)
+		return nil, status.Errorf(codes.Unavailable, "failed to sample metrics: %v", err)
 	}
 
-	return &workerPB.MetricsUpdate{
-		CpuUtilizationRaw:        metrics.CPUUtilizationRaw,
-		CpuUtilizationPercent:    metrics.CPUUtilizationPercent,
-		MemoryUtilizationRaw:     metrics.MemoryUtilizationRaw,
-		MemoryUtilizationPercent: metrics.MemoryUtilizationPercent,
-	}, nil
+	return metricsToProto(metrics), nil
 }
 
 func (s *Controller) MetricsStream(req *workerPB.MetricsRequest, stream grpc.ServerStreamingServer[workerPB.MetricsUpdate]) error {
@@ -186,27 +185,16 @@ func (s *Controller) MetricsStream(req *workerPB.MetricsRequest, stream grpc.Ser
 	if interval <= 0 {
 		interval = time.Second
 	}
-	if _, ok := s.metricsSampler.Latest(); !ok {
-		if _, err := s.metricsSampler.Sample(); err != nil {
-			s.logger.Error("failed to sample metrics", "error", err)
-			return status.Errorf(codes.Unavailable, "failed to sample metrics: %v", err)
-		}
-	}
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	sendLatest := func() error {
-		metrics, ok := s.metricsSampler.Latest()
-		if !ok {
+		metrics, err := s.getMetricsSnapshot()
+		if err != nil {
 			return status.Error(codes.Unavailable, "metrics unavailable")
 		}
-		return stream.Send(&workerPB.MetricsUpdate{
-			CpuUtilizationRaw:        metrics.CPUUtilizationRaw,
-			CpuUtilizationPercent:    metrics.CPUUtilizationPercent,
-			MemoryUtilizationRaw:     metrics.MemoryUtilizationRaw,
-			MemoryUtilizationPercent: metrics.MemoryUtilizationPercent,
-		})
+		return stream.Send(metricsToProto(metrics))
 	}
 
 	if err := sendLatest(); err != nil {
@@ -235,17 +223,31 @@ func NewController(runtime cr.ContainerRuntime,
 	readySignals *ReadySignals,
 	containerized bool,
 	metricsInterval time.Duration,
+	workerBudgetCPU float64,
+	workerBudgetMemory uint64,
 ) *Controller {
 	metricsSampler := stats.NewMetricsSampler(containerized, logger.With("component", "metrics_sampler"))
+	var resourceManager *ResourceManager
+	var workerContainerID string
+	if containerized {
+		resourceManager = NewResourceManager(runtime, logger, metricsInterval, workerBudgetCPU, workerBudgetMemory)
+		if hostname, err := os.Hostname(); err == nil {
+			workerContainerID = hostname
+		} else {
+			logger.Warn("failed to read hostname for worker container", "error", err)
+		}
+	}
 	return &Controller{
-		runtime:         runtime,
-		StatsManager:    statsManager,
-		metricsSampler:  metricsSampler,
-		metricsInterval: metricsInterval,
-		logger:          logger,
-		address:         address,
-		metadataClient:  metadataClient,
-		readySignals:    readySignals,
+		runtime:           runtime,
+		StatsManager:      statsManager,
+		metricsSampler:    metricsSampler,
+		metricsInterval:   metricsInterval,
+		resourceManager:   resourceManager,
+		workerContainerID: workerContainerID,
+		logger:            logger,
+		address:           address,
+		metadataClient:    metadataClient,
+		readySignals:      readySignals,
 	}
 }
 
@@ -259,7 +261,15 @@ func (s *Controller) StartServer(ctx context.Context) {
 	// defer cancel()
 
 	// Start the stats manager
-	go s.metricsSampler.Run(ctx, s.metricsInterval)
+	if s.resourceManager != nil {
+		s.resourceManager.SetContext(ctx)
+		if s.workerContainerID != "" {
+			s.resourceManager.AddContainer(s.workerContainerID)
+		}
+		go s.resourceManager.Run(ctx)
+	} else {
+		go s.metricsSampler.Run(ctx, s.metricsInterval)
+	}
 	go func() {
 		s.StatsManager.StartStreamingToListeners(ctx)
 	}()
@@ -320,5 +330,36 @@ func (s *Controller) monitorContainerLifecycle(functionID string, c cr.Container
 		s.StatsManager.Enqueue(stats.Event().Function(functionID).Container(c.Id).Down().Failed())
 	default:
 		s.logger.Debug("Unexpected container event", "instanceID", c.Id, "event", event)
+	}
+	if s.resourceManager != nil {
+		s.resourceManager.RemoveContainer(c.Id)
+	}
+}
+
+func (s *Controller) getMetricsSnapshot() (sharedmetrics.ResourceMetrics, error) {
+	if s.resourceManager != nil {
+		metrics, ok := s.resourceManager.Latest()
+		if !ok {
+			return sharedmetrics.ResourceMetrics{}, errors.New("metrics unavailable")
+		}
+		return metrics, nil
+	}
+	metrics, ok := s.metricsSampler.Latest()
+	if ok {
+		return metrics, nil
+	}
+	metrics, err := s.metricsSampler.Sample()
+	if err != nil {
+		return sharedmetrics.ResourceMetrics{}, err
+	}
+	return metrics, nil
+}
+
+func metricsToProto(metrics sharedmetrics.ResourceMetrics) *workerPB.MetricsUpdate {
+	return &workerPB.MetricsUpdate{
+		CpuUtilizationRaw:        metrics.CPUUtilizationRaw,
+		CpuUtilizationPercent:    metrics.CPUUtilizationPercent,
+		MemoryUtilizationRaw:     metrics.MemoryUtilizationRaw,
+		MemoryUtilizationPercent: metrics.MemoryUtilizationPercent,
 	}
 }

--- a/pkg/worker/controller/controller.go
+++ b/pkg/worker/controller/controller.go
@@ -14,8 +14,6 @@ import (
 	cr "github.com/3s-rg-codes/HyperFaaS/pkg/worker/containerRuntime"
 	"github.com/3s-rg-codes/HyperFaaS/pkg/worker/stats"
 	workerPB "github.com/3s-rg-codes/HyperFaaS/proto/worker"
-	cpu "github.com/shirou/gopsutil/v4/cpu"
-	mem "github.com/shirou/gopsutil/v4/mem"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
@@ -27,12 +25,14 @@ import (
 
 type Controller struct {
 	workerPB.UnimplementedWorkerServer
-	runtime        cr.ContainerRuntime
-	StatsManager   *stats.StatsManager
-	logger         *slog.Logger
-	address        string
-	metadataClient metadataProvider
-	readySignals   *ReadySignals
+	runtime         cr.ContainerRuntime
+	StatsManager    *stats.StatsManager
+	metricsSampler  *stats.MetricsSampler
+	metricsInterval time.Duration
+	logger          *slog.Logger
+	address         string
+	metadataClient  metadataProvider
+	readySignals    *ReadySignals
 }
 type metadataProvider interface {
 	GetFunction(ctx context.Context, id string) (*metadata.FunctionMetadata, error)
@@ -162,13 +162,69 @@ func (s *Controller) Status(req *workerPB.StatusRequest, stream workerPB.Worker_
 }
 
 func (s *Controller) Metrics(ctx context.Context, req *workerPB.MetricsRequest) (*workerPB.MetricsUpdate, error) {
-	cpu_percentage_percpu, err1 := cpu.Percent(time.Millisecond*10, true)
-	virtual_mem, err2 := mem.VirtualMemory()
-
-	if err1 != nil || err2 != nil {
-		return nil, err1
+	metrics, ok := s.metricsSampler.Latest()
+	if !ok {
+		var err error
+		metrics, err = s.metricsSampler.Sample()
+		if err != nil {
+			s.logger.Error("failed to sample metrics", "error", err)
+			return nil, status.Errorf(codes.Unavailable, "failed to sample metrics: %v", err)
+		}
 	}
-	return &workerPB.MetricsUpdate{CpuPercentPercpus: cpu_percentage_percpu, UsedRamPercent: virtual_mem.UsedPercent}, nil
+
+	return &workerPB.MetricsUpdate{
+		CpuUtilizationRaw:        metrics.CPUUtilizationRaw,
+		CpuUtilizationPercent:    metrics.CPUUtilizationPercent,
+		MemoryUtilizationRaw:     metrics.MemoryUtilizationRaw,
+		MemoryUtilizationPercent: metrics.MemoryUtilizationPercent,
+	}, nil
+}
+
+func (s *Controller) MetricsStream(req *workerPB.MetricsRequest, stream grpc.ServerStreamingServer[workerPB.MetricsUpdate]) error {
+	ctx := stream.Context()
+	interval := s.metricsInterval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	if _, ok := s.metricsSampler.Latest(); !ok {
+		if _, err := s.metricsSampler.Sample(); err != nil {
+			s.logger.Error("failed to sample metrics", "error", err)
+			return status.Errorf(codes.Unavailable, "failed to sample metrics: %v", err)
+		}
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	sendLatest := func() error {
+		metrics, ok := s.metricsSampler.Latest()
+		if !ok {
+			return status.Error(codes.Unavailable, "metrics unavailable")
+		}
+		return stream.Send(&workerPB.MetricsUpdate{
+			CpuUtilizationRaw:        metrics.CPUUtilizationRaw,
+			CpuUtilizationPercent:    metrics.CPUUtilizationPercent,
+			MemoryUtilizationRaw:     metrics.MemoryUtilizationRaw,
+			MemoryUtilizationPercent: metrics.MemoryUtilizationPercent,
+		})
+	}
+
+	if err := sendLatest(); err != nil {
+		s.logger.Error("error streaming metrics", "error", err, "node_id", req.NodeId)
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := sendLatest(); err != nil {
+				s.logger.Error("error streaming metrics", "error", err, "node_id", req.NodeId)
+				return err
+			}
+		}
+	}
 }
 
 func NewController(runtime cr.ContainerRuntime,
@@ -177,14 +233,19 @@ func NewController(runtime cr.ContainerRuntime,
 	address string,
 	metadataClient metadataProvider,
 	readySignals *ReadySignals,
+	containerized bool,
+	metricsInterval time.Duration,
 ) *Controller {
+	metricsSampler := stats.NewMetricsSampler(containerized, logger.With("component", "metrics_sampler"))
 	return &Controller{
-		runtime:        runtime,
-		StatsManager:   statsManager,
-		logger:         logger,
-		address:        address,
-		metadataClient: metadataClient,
-		readySignals:   readySignals,
+		runtime:         runtime,
+		StatsManager:    statsManager,
+		metricsSampler:  metricsSampler,
+		metricsInterval: metricsInterval,
+		logger:          logger,
+		address:         address,
+		metadataClient:  metadataClient,
+		readySignals:    readySignals,
 	}
 }
 
@@ -198,7 +259,7 @@ func (s *Controller) StartServer(ctx context.Context) {
 	// defer cancel()
 
 	// Start the stats manager
-
+	go s.metricsSampler.Run(ctx, s.metricsInterval)
 	go func() {
 		s.StatsManager.StartStreamingToListeners(ctx)
 	}()

--- a/pkg/worker/controller/mock.go
+++ b/pkg/worker/controller/mock.go
@@ -19,7 +19,27 @@ type MockController struct {
 // Metrics implements worker.WorkerServer.
 // Subtle: this method shadows the method (UnimplementedWorkerServer).Metrics of MockController.UnimplementedWorkerServer.
 func (m MockController) Metrics(context.Context, *workerpb.MetricsRequest) (*workerpb.MetricsUpdate, error) {
-	panic("unimplemented")
+	return &workerpb.MetricsUpdate{
+		CpuUtilizationRaw:        0,
+		CpuUtilizationPercent:    0,
+		MemoryUtilizationRaw:     0,
+		MemoryUtilizationPercent: 0,
+	}, nil
+}
+
+func (m MockController) MetricsStream(_ *workerpb.MetricsRequest, stream grpc.ServerStreamingServer[workerpb.MetricsUpdate]) error {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		case <-ticker.C:
+			if err := stream.Send(&workerpb.MetricsUpdate{}); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 // SignalReady implements worker.WorkerServer.

--- a/pkg/worker/controller/ready_signals.go
+++ b/pkg/worker/controller/ready_signals.go
@@ -6,15 +6,23 @@ import "sync"
 // This is used in the controller to block until an instance is ready before returning in the Start function.
 // This ensures that clients can start calling the instance immediately after starting it.
 type ReadySignals struct {
-	readySignals map[string]chan struct{}
+	readySignals map[string]*readyState
 	mu           sync.RWMutex
 	// wether the readySignals are mocked. Used for testing.
 	mocked bool
 }
 
+type readyState struct {
+	ready bool
+	ch    chan struct{}
+}
+
 // NewReadySignals creates a new ReadySignals instance. Use mocked: true to use the mocked runtime.
 func NewReadySignals(mocked bool) *ReadySignals {
-	return &ReadySignals{readySignals: make(map[string]chan struct{}), mocked: mocked}
+	return &ReadySignals{
+		readySignals: make(map[string]*readyState),
+		mocked:       mocked,
+	}
 }
 
 // AddInstance adds a new instance to the readySignals map.
@@ -24,21 +32,41 @@ func (s *ReadySignals) AddInstance(instanceID string) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.readySignals[instanceID] = make(chan struct{})
+	state := s.readySignals[instanceID]
+	if state == nil {
+		s.readySignals[instanceID] = &readyState{ch: make(chan struct{})}
+		return
+	}
+	if state.ready {
+		delete(s.readySignals, instanceID)
+		return
+	}
+	if state.ch == nil {
+		state.ch = make(chan struct{})
+	}
 }
 
 // SignalReady signals that the instance is ready to serve requests.
 func (s *ReadySignals) SignalReady(instanceID string) {
+	if s.mocked {
+		return
+	}
 	s.mu.Lock()
-	c := s.readySignals[instanceID]
-	s.mu.Unlock()
-	if c != nil {
-		c <- struct{}{}
-		s.mu.Lock()
-		close(c)
+	state := s.readySignals[instanceID]
+	if state == nil {
+		s.readySignals[instanceID] = &readyState{ready: true}
+		s.mu.Unlock()
+		return
+	}
+	if state.ch != nil {
+		ch := state.ch
 		delete(s.readySignals, instanceID)
 		s.mu.Unlock()
+		close(ch)
+		return
 	}
+	state.ready = true
+	s.mu.Unlock()
 }
 
 // WaitReady blocks until the instance is ready to serve requests.
@@ -47,9 +75,21 @@ func (s *ReadySignals) WaitReady(instanceID string) {
 		return
 	}
 	s.mu.RLock()
-	c := s.readySignals[instanceID]
+	state := s.readySignals[instanceID]
 	s.mu.RUnlock()
-	if c != nil {
-		<-c
+	if state == nil {
+		return
+	}
+	if state.ready {
+		s.mu.Lock()
+		delete(s.readySignals, instanceID)
+		s.mu.Unlock()
+		return
+	}
+	if state.ch != nil {
+		<-state.ch
+		s.mu.Lock()
+		delete(s.readySignals, instanceID)
+		s.mu.Unlock()
 	}
 }

--- a/pkg/worker/controller/ready_signals_test.go
+++ b/pkg/worker/controller/ready_signals_test.go
@@ -1,0 +1,55 @@
+//go:build unit
+
+package controller
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReadySignalsSignalBeforeAdd(t *testing.T) {
+	signals := NewReadySignals(false)
+	instanceID := "instance-1"
+
+	signals.SignalReady(instanceID)
+	signals.AddInstance(instanceID)
+
+	done := make(chan struct{})
+	go func() {
+		signals.WaitReady(instanceID)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("WaitReady timed out after ready signal")
+	}
+}
+
+func TestReadySignalsAddBeforeSignal(t *testing.T) {
+	signals := NewReadySignals(false)
+	instanceID := "instance-2"
+
+	signals.AddInstance(instanceID)
+
+	done := make(chan struct{})
+	go func() {
+		signals.WaitReady(instanceID)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("WaitReady returned before signal")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	signals.SignalReady(instanceID)
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("WaitReady did not return after signal")
+	}
+}

--- a/pkg/worker/controller/resource_manager.go
+++ b/pkg/worker/controller/resource_manager.go
@@ -1,0 +1,202 @@
+package controller
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	mtrcs "github.com/3s-rg-codes/HyperFaaS/pkg/metrics"
+	cr "github.com/3s-rg-codes/HyperFaaS/pkg/worker/containerRuntime"
+)
+
+// ResourceManager is responsible for managing the resources of the worker.
+// for now it's only useful to generate the simulated aggregate metrics for the worker.
+// to calculate the aggregate usage, we sum up the worker's usage and the instances' usage.
+// in a "bare metal" setup, this is of course not needed, as we can just work directly with the
+// available system resources. But for the docker-compose setup, this gives us a way to simulate
+// the aggregate usage of the worker.
+// However, this manager might be useful to implement guards against starting instances when
+// the worker is already at max capacity. Note that capacity != actual usage.
+type ResourceManager struct {
+	runtime      cr.ContainerRuntime
+	logger       *slog.Logger
+	interval     time.Duration
+	budgetCPU    float64
+	budgetMemory uint64
+
+	mu         sync.Mutex
+	containers map[string]*containerEntry
+	updates    chan containerUpdate
+	ctx        context.Context
+	latest     atomic.Value
+}
+
+type containerEntry struct {
+	lastUsage uint64
+	prevUsage uint64
+	lastMem   uint64
+	cancel    context.CancelFunc
+}
+
+type containerUpdate struct {
+	containerID string
+	stats       cr.ContainerStats
+}
+
+func NewResourceManager(runtime cr.ContainerRuntime, logger *slog.Logger, interval time.Duration, budgetCPU float64, budgetMemory uint64) *ResourceManager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if interval <= 0 {
+		interval = time.Second
+	}
+	return &ResourceManager{
+		runtime:      runtime,
+		logger:       logger.With("component", "resource_manager"),
+		interval:     interval,
+		budgetCPU:    budgetCPU,
+		budgetMemory: budgetMemory,
+		containers:   make(map[string]*containerEntry),
+		updates:      make(chan containerUpdate, 1024),
+	}
+}
+
+func (r *ResourceManager) Run(ctx context.Context) {
+	if r.ctx == nil {
+		r.ctx = ctx
+	}
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case update := <-r.updates:
+			r.mu.Lock()
+			entry := r.containers[update.containerID]
+			if entry != nil {
+				entry.lastUsage = update.stats.CPUUsageTotal
+				entry.lastMem = update.stats.MemoryUsage
+			}
+			r.mu.Unlock()
+		case <-ticker.C:
+			r.aggregate()
+		}
+	}
+}
+
+func (r *ResourceManager) SetContext(ctx context.Context) {
+	r.ctx = ctx
+}
+
+func (r *ResourceManager) AddContainer(containerID string) {
+	if containerID == "" {
+		return
+	}
+
+	r.mu.Lock()
+	if _, exists := r.containers[containerID]; exists {
+		r.mu.Unlock()
+		return
+	}
+	baseCtx := r.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(baseCtx)
+	r.containers[containerID] = &containerEntry{cancel: cancel}
+	r.mu.Unlock()
+
+	statsCh, errCh := r.runtime.ContainerStats(ctx, containerID)
+	go r.consumeStats(ctx, containerID, statsCh, errCh)
+}
+
+func (r *ResourceManager) RemoveContainer(containerID string) {
+	if containerID == "" {
+		return
+	}
+	r.mu.Lock()
+	entry := r.containers[containerID]
+	if entry == nil {
+		for id, candidate := range r.containers {
+			if len(containerID) <= len(id) && id[:len(containerID)] == containerID {
+				entry = candidate
+				containerID = id
+				break
+			}
+		}
+	}
+	if entry != nil {
+		entry.cancel()
+		delete(r.containers, containerID)
+	}
+	r.mu.Unlock()
+}
+
+func (r *ResourceManager) Latest() (mtrcs.ResourceMetrics, bool) {
+	value := r.latest.Load()
+	if value == nil {
+		return mtrcs.ResourceMetrics{}, false
+	}
+	metrics, ok := value.(mtrcs.ResourceMetrics)
+	return metrics, ok
+}
+
+func (r *ResourceManager) consumeStats(ctx context.Context, containerID string, statsCh <-chan cr.ContainerStats, errCh <-chan error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case stat, ok := <-statsCh:
+			if !ok {
+				return
+			}
+			select {
+			case r.updates <- containerUpdate{containerID: containerID, stats: stat}:
+			default:
+				r.logger.Warn("resource manager buffer full", "container", containerID)
+			}
+		case err, ok := <-errCh:
+			if ok && err != nil {
+				r.logger.Debug("container stats stream ended", "container", containerID, "error", err)
+			}
+			return
+		}
+	}
+}
+
+func (r *ResourceManager) aggregate() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var totalUsage uint64
+	var totalMemory uint64
+	for _, entry := range r.containers {
+		if entry.lastUsage > 0 {
+			if entry.prevUsage > 0 && entry.lastUsage >= entry.prevUsage {
+				totalUsage += entry.lastUsage - entry.prevUsage
+			}
+			entry.prevUsage = entry.lastUsage
+		}
+		totalMemory += entry.lastMem
+	}
+
+	metrics := mtrcs.ResourceMetrics{
+		CPUUtilizationRaw:    float64(totalUsage),
+		MemoryUtilizationRaw: float64(totalMemory),
+	}
+
+	intervalSeconds := r.interval.Seconds()
+	if r.budgetCPU > 0 && intervalSeconds > 0 {
+		usageSeconds := float64(totalUsage) / 1e9
+		usagePerCore := usageSeconds / intervalSeconds
+		metrics.CPUUtilizationPercent = float32((usagePerCore / r.budgetCPU) * 100)
+	}
+	if r.budgetMemory > 0 {
+		metrics.MemoryUtilizationPercent = float32((float64(totalMemory) / float64(r.budgetMemory)) * 100)
+	}
+
+	r.latest.Store(metrics)
+}

--- a/pkg/worker/stats/metrics.go
+++ b/pkg/worker/stats/metrics.go
@@ -1,0 +1,345 @@
+package stats
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+type ResourceMetrics struct {
+	CPUUtilizationRaw        float64
+	CPUUtilizationPercent    float32
+	MemoryUtilizationRaw     float64
+	MemoryUtilizationPercent float32
+}
+
+type MetricsSampler struct {
+	containerized bool
+
+	logger *slog.Logger
+	mu     sync.Mutex
+
+	lastTotal    float64
+	lastIdle     float64
+	lastCPUUsage float64
+	lastSample   time.Time
+	initialized  bool
+
+	snapshot atomic.Value
+}
+
+func NewMetricsSampler(containerized bool, logger *slog.Logger) *MetricsSampler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MetricsSampler{
+		containerized: containerized,
+		logger:        logger,
+	}
+}
+
+func (s *MetricsSampler) Run(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	if _, err := s.Sample(); err != nil {
+		s.logger.Debug("metrics sampler initial sample failed", "error", err)
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := s.Sample(); err != nil {
+				s.logger.Debug("metrics sampler tick failed", "error", err)
+			}
+		}
+	}
+}
+
+func (s *MetricsSampler) Latest() (ResourceMetrics, bool) {
+	value := s.snapshot.Load()
+	if value == nil {
+		return ResourceMetrics{}, false
+	}
+	metrics, ok := value.(ResourceMetrics)
+	return metrics, ok
+}
+
+// Sample collects metrics and stores them as the latest snapshot.
+func (s *MetricsSampler) Sample() (ResourceMetrics, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	metrics, err := s.sampleLocked()
+	if err != nil {
+		return ResourceMetrics{}, err
+	}
+	s.snapshot.Store(metrics)
+	return metrics, nil
+}
+
+func (s *MetricsSampler) sampleLocked() (ResourceMetrics, error) {
+	if s.containerized {
+		return s.sampleContainerized()
+	}
+
+	return s.sampleHost()
+}
+
+func (s *MetricsSampler) sampleHost() (ResourceMetrics, error) {
+	times, err := cpu.Times(false)
+	if err != nil {
+		return ResourceMetrics{}, err
+	}
+	if len(times) == 0 {
+		return ResourceMetrics{}, nil
+	}
+	memStat, err := mem.VirtualMemory()
+	if err != nil {
+		return ResourceMetrics{}, err
+	}
+
+	total := totalCPUTimes(&times[0])
+	idle := times[0].Idle + times[0].Iowait
+
+	metrics := ResourceMetrics{}
+	if memStat != nil {
+		metrics.MemoryUtilizationRaw = float64(memStat.Used)
+		metrics.MemoryUtilizationPercent = float32(memStat.UsedPercent)
+	}
+
+	if !s.initialized {
+		s.lastTotal = total
+		s.lastIdle = idle
+		s.initialized = true
+		// The first sample cannot compute a delta yet, so CPU metrics remain zero.
+		return metrics, nil
+	}
+
+	deltaTotal := total - s.lastTotal
+	deltaIdle := idle - s.lastIdle
+	s.lastTotal = total
+	s.lastIdle = idle
+
+	metrics.CPUUtilizationPercent, metrics.CPUUtilizationRaw = cpuMetricsFromDelta(deltaTotal, deltaIdle)
+	return metrics, nil
+}
+
+func (s *MetricsSampler) sampleContainerized() (ResourceMetrics, error) {
+	usage, err := readCgroupV2CPUUsage()
+	if err != nil {
+		return ResourceMetrics{}, err
+	}
+	memUsage, memLimit, err := readCgroupV2Memory()
+	if err != nil {
+		return ResourceMetrics{}, err
+	}
+	quotaCores, err := readCgroupV2CPUQuotaCores()
+	if err != nil || quotaCores <= 0 {
+		quotaCores, err = readCgroupV2CPUSetCores()
+		if err != nil {
+			return ResourceMetrics{}, err
+		}
+	}
+
+	now := time.Now()
+	metrics := ResourceMetrics{}
+	metrics.MemoryUtilizationRaw = float64(memUsage)
+	if memLimit > 0 && !isUnlimitedMem(memLimit) {
+		metrics.MemoryUtilizationPercent = float32(float64(memUsage) / float64(memLimit) * 100)
+	}
+
+	if s.lastSample.IsZero() {
+		s.lastCPUUsage = usage
+		s.lastSample = now
+		return metrics, nil
+	}
+
+	elapsed := now.Sub(s.lastSample).Seconds()
+	deltaUsage := usage - s.lastCPUUsage
+	s.lastCPUUsage = usage
+	s.lastSample = now
+
+	if quotaCores <= 0 {
+		return metrics, nil
+	}
+
+	if elapsed > 0 && deltaUsage >= 0 {
+		usagePerCore := deltaUsage / elapsed
+		metrics.CPUUtilizationPercent = float32((usagePerCore / quotaCores) * 100)
+		// Raw CPU time uses the cgroup usage delta, which is already in seconds.
+		metrics.CPUUtilizationRaw = deltaUsage * float64(time.Second)
+	}
+
+	return metrics, nil
+}
+
+func totalCPUTimes(stat *cpu.TimesStat) float64 {
+	if stat == nil {
+		return 0
+	}
+	return stat.User + stat.Nice + stat.System + stat.Idle + stat.Iowait + stat.Irq + stat.Softirq + stat.Steal + stat.Guest + stat.GuestNice
+}
+
+func cpuMetricsFromDelta(deltaTotal, deltaIdle float64) (float32, float64) {
+	if deltaTotal <= 0 {
+		return 0, 0
+	}
+	busy := deltaTotal - deltaIdle
+	if busy < 0 {
+		busy = 0
+	}
+	percent := float32((busy / deltaTotal) * 100)
+	raw := busy * float64(time.Second)
+	return percent, raw
+}
+
+func readCgroupV2CPUUsage() (float64, error) {
+	path := "/sys/fs/cgroup/cpu.stat"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	lines := strings.SplitSeq(string(data), "\n")
+	for line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		if fields[0] == "usage_usec" {
+			value, err := strconv.ParseFloat(fields[1], 64)
+			if err != nil {
+				return 0, err
+			}
+			return value / 1e6, nil
+		}
+	}
+	return 0, errors.New("usage_usec not found")
+}
+
+// this will return 0 if the memory limit is unlimited
+func readCgroupV2Memory() (uint64, uint64, error) {
+	usage, err := readUint64("/sys/fs/cgroup/memory.current")
+	if err != nil {
+		return 0, 0, err
+	}
+	limit, err := readUint64OrMax("/sys/fs/cgroup/memory.max")
+	if err != nil {
+		return 0, 0, err
+	}
+	return usage, limit, nil
+}
+
+func readCgroupV2CPUQuotaCores() (float64, error) {
+	path := "/sys/fs/cgroup/cpu.max"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 2 {
+		return 0, errors.New("cpu.max format invalid")
+	}
+	if fields[0] == "max" {
+		return 0, errors.New("cpu quota not set")
+	}
+	quota, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, err
+	}
+	period, err := strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return 0, err
+	}
+	if quota <= 0 || period <= 0 {
+		return 0, errors.New("cpu quota invalid")
+	}
+	return quota / period, nil
+}
+
+func readUint64(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	value := strings.TrimSpace(string(data))
+	return strconv.ParseUint(value, 10, 64)
+}
+
+func readUint64OrMax(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "max" {
+		return ^uint64(0), nil
+	}
+	return strconv.ParseUint(value, 10, 64)
+}
+
+func readCgroupV2CPUSetCores() (float64, error) {
+	data, err := os.ReadFile("/sys/fs/cgroup/cpuset.cpus.effective")
+	if err != nil {
+		return 0, err
+	}
+	value := strings.TrimSpace(string(data))
+	cores, err := parseCPUSet(value)
+	if err != nil {
+		return 0, err
+	}
+	if cores <= 0 {
+		return 0, errors.New("cpuset empty")
+	}
+	return float64(cores), nil
+}
+
+func parseCPUSet(value string) (int, error) {
+	if value == "" {
+		return 0, errors.New("cpuset empty")
+	}
+	count := 0
+	ranges := strings.SplitSeq(value, ",")
+	for entry := range ranges {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		parts := strings.Split(entry, "-")
+		if len(parts) == 1 {
+			count++
+			continue
+		}
+		if len(parts) != 2 {
+			return 0, errors.New("cpuset format invalid")
+		}
+		start, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, err
+		}
+		end, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, err
+		}
+		if end < start {
+			return 0, errors.New("cpuset range invalid")
+		}
+		count += end - start + 1
+	}
+	return count, nil
+}
+
+func isUnlimitedMem(limit uint64) bool {
+	return limit >= (1<<63 - 1)
+}

--- a/pkg/worker/stats/metrics.go
+++ b/pkg/worker/stats/metrics.go
@@ -11,16 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	mtrcs "github.com/3s-rg-codes/HyperFaaS/pkg/metrics"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/mem"
 )
-
-type ResourceMetrics struct {
-	CPUUtilizationRaw        float64
-	CPUUtilizationPercent    float32
-	MemoryUtilizationRaw     float64
-	MemoryUtilizationPercent float32
-}
 
 type MetricsSampler struct {
 	containerized bool
@@ -68,28 +62,28 @@ func (s *MetricsSampler) Run(ctx context.Context, interval time.Duration) {
 	}
 }
 
-func (s *MetricsSampler) Latest() (ResourceMetrics, bool) {
+func (s *MetricsSampler) Latest() (mtrcs.ResourceMetrics, bool) {
 	value := s.snapshot.Load()
 	if value == nil {
-		return ResourceMetrics{}, false
+		return mtrcs.ResourceMetrics{}, false
 	}
-	metrics, ok := value.(ResourceMetrics)
+	metrics, ok := value.(mtrcs.ResourceMetrics)
 	return metrics, ok
 }
 
 // Sample collects metrics and stores them as the latest snapshot.
-func (s *MetricsSampler) Sample() (ResourceMetrics, error) {
+func (s *MetricsSampler) Sample() (mtrcs.ResourceMetrics, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	metrics, err := s.sampleLocked()
 	if err != nil {
-		return ResourceMetrics{}, err
+		return mtrcs.ResourceMetrics{}, err
 	}
 	s.snapshot.Store(metrics)
 	return metrics, nil
 }
 
-func (s *MetricsSampler) sampleLocked() (ResourceMetrics, error) {
+func (s *MetricsSampler) sampleLocked() (mtrcs.ResourceMetrics, error) {
 	if s.containerized {
 		return s.sampleContainerized()
 	}
@@ -97,23 +91,23 @@ func (s *MetricsSampler) sampleLocked() (ResourceMetrics, error) {
 	return s.sampleHost()
 }
 
-func (s *MetricsSampler) sampleHost() (ResourceMetrics, error) {
+func (s *MetricsSampler) sampleHost() (mtrcs.ResourceMetrics, error) {
 	times, err := cpu.Times(false)
 	if err != nil {
-		return ResourceMetrics{}, err
+		return mtrcs.ResourceMetrics{}, err
 	}
 	if len(times) == 0 {
-		return ResourceMetrics{}, nil
+		return mtrcs.ResourceMetrics{}, nil
 	}
 	memStat, err := mem.VirtualMemory()
 	if err != nil {
-		return ResourceMetrics{}, err
+		return mtrcs.ResourceMetrics{}, err
 	}
 
 	total := totalCPUTimes(&times[0])
 	idle := times[0].Idle + times[0].Iowait
 
-	metrics := ResourceMetrics{}
+	metrics := mtrcs.ResourceMetrics{}
 	if memStat != nil {
 		metrics.MemoryUtilizationRaw = float64(memStat.Used)
 		metrics.MemoryUtilizationPercent = float32(memStat.UsedPercent)
@@ -136,25 +130,25 @@ func (s *MetricsSampler) sampleHost() (ResourceMetrics, error) {
 	return metrics, nil
 }
 
-func (s *MetricsSampler) sampleContainerized() (ResourceMetrics, error) {
+func (s *MetricsSampler) sampleContainerized() (mtrcs.ResourceMetrics, error) {
 	usage, err := readCgroupV2CPUUsage()
 	if err != nil {
-		return ResourceMetrics{}, err
+		return mtrcs.ResourceMetrics{}, err
 	}
 	memUsage, memLimit, err := readCgroupV2Memory()
 	if err != nil {
-		return ResourceMetrics{}, err
+		return mtrcs.ResourceMetrics{}, err
 	}
 	quotaCores, err := readCgroupV2CPUQuotaCores()
 	if err != nil || quotaCores <= 0 {
 		quotaCores, err = readCgroupV2CPUSetCores()
 		if err != nil {
-			return ResourceMetrics{}, err
+			return mtrcs.ResourceMetrics{}, err
 		}
 	}
 
 	now := time.Now()
-	metrics := ResourceMetrics{}
+	metrics := mtrcs.ResourceMetrics{}
 	metrics.MemoryUtilizationRaw = float64(memUsage)
 	if memLimit > 0 && !isUnlimitedMem(memLimit) {
 		metrics.MemoryUtilizationPercent = float32(float64(memUsage) / float64(memLimit) * 100)

--- a/pkg/worker/stats/metrics_test.go
+++ b/pkg/worker/stats/metrics_test.go
@@ -1,0 +1,55 @@
+//go:build unit
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+)
+
+func TestTotalCPUTimes(t *testing.T) {
+	stat := cpu.TimesStat{
+		User:      1,
+		Nice:      2,
+		System:    3,
+		Idle:      4,
+		Iowait:    5,
+		Irq:       6,
+		Softirq:   7,
+		Steal:     8,
+		Guest:     9,
+		GuestNice: 10,
+	}
+	if got := totalCPUTimes(&stat); got != 55 {
+		t.Fatalf("unexpected total cpu times: %v", got)
+	}
+}
+
+func TestCPUMetricsFromDelta(t *testing.T) {
+	percent, raw := cpuMetricsFromDelta(10, 4)
+	if percent < 59.9 || percent > 60.1 {
+		t.Fatalf("unexpected cpu percent: %v", percent)
+	}
+	if raw <= 0 {
+		t.Fatalf("expected raw cpu to be positive")
+	}
+}
+
+func TestParseCPUSet(t *testing.T) {
+	cores, err := parseCPUSet("0-3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cores != 4 {
+		t.Fatalf("unexpected core count: %v", cores)
+	}
+
+	cores, err = parseCPUSet("0-1,4,6-7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cores != 5 {
+		t.Fatalf("unexpected core count: %v", cores)
+	}
+}

--- a/proto/worker/worker.pb.go
+++ b/proto/worker/worker.pb.go
@@ -347,11 +347,13 @@ func (x *MetricsRequest) GetNodeId() string {
 }
 
 type MetricsUpdate struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	UsedRamPercent    float64                `protobuf:"fixed64,1,opt,name=used_ram_percent,json=usedRamPercent,proto3" json:"used_ram_percent,omitempty"`
-	CpuPercentPercpus []float64              `protobuf:"fixed64,2,rep,packed,name=cpu_percent_percpus,json=cpuPercentPercpus,proto3" json:"cpu_percent_percpus,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	CpuUtilizationRaw        float64                `protobuf:"fixed64,1,opt,name=cpu_utilization_raw,json=cpuUtilizationRaw,proto3" json:"cpu_utilization_raw,omitempty"`
+	CpuUtilizationPercent    float32                `protobuf:"fixed32,2,opt,name=cpu_utilization_percent,json=cpuUtilizationPercent,proto3" json:"cpu_utilization_percent,omitempty"`
+	MemoryUtilizationRaw     float64                `protobuf:"fixed64,3,opt,name=memory_utilization_raw,json=memoryUtilizationRaw,proto3" json:"memory_utilization_raw,omitempty"`
+	MemoryUtilizationPercent float32                `protobuf:"fixed32,4,opt,name=memory_utilization_percent,json=memoryUtilizationPercent,proto3" json:"memory_utilization_percent,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *MetricsUpdate) Reset() {
@@ -384,18 +386,32 @@ func (*MetricsUpdate) Descriptor() ([]byte, []int) {
 	return file_worker_worker_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *MetricsUpdate) GetUsedRamPercent() float64 {
+func (x *MetricsUpdate) GetCpuUtilizationRaw() float64 {
 	if x != nil {
-		return x.UsedRamPercent
+		return x.CpuUtilizationRaw
 	}
 	return 0
 }
 
-func (x *MetricsUpdate) GetCpuPercentPercpus() []float64 {
+func (x *MetricsUpdate) GetCpuUtilizationPercent() float32 {
 	if x != nil {
-		return x.CpuPercentPercpus
+		return x.CpuUtilizationPercent
 	}
-	return nil
+	return 0
+}
+
+func (x *MetricsUpdate) GetMemoryUtilizationRaw() float64 {
+	if x != nil {
+		return x.MemoryUtilizationRaw
+	}
+	return 0
+}
+
+func (x *MetricsUpdate) GetMemoryUtilizationPercent() float32 {
+	if x != nil {
+		return x.MemoryUtilizationPercent
+	}
+	return 0
 }
 
 type StartResponse struct {
@@ -659,10 +675,12 @@ const file_worker_worker_proto_rawDesc = "" +
 	"\rStatusRequest\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\tR\x06nodeId\")\n" +
 	"\x0eMetricsRequest\x12\x17\n" +
-	"\anode_id\x18\x01 \x01(\tR\x06nodeId\"i\n" +
-	"\rMetricsUpdate\x12(\n" +
-	"\x10used_ram_percent\x18\x01 \x01(\x01R\x0eusedRamPercent\x12.\n" +
-	"\x13cpu_percent_percpus\x18\x02 \x03(\x01R\x11cpuPercentPercpus\"\xb9\x01\n" +
+	"\anode_id\x18\x01 \x01(\tR\x06nodeId\"\xeb\x01\n" +
+	"\rMetricsUpdate\x12.\n" +
+	"\x13cpu_utilization_raw\x18\x01 \x01(\x01R\x11cpuUtilizationRaw\x126\n" +
+	"\x17cpu_utilization_percent\x18\x02 \x01(\x02R\x15cpuUtilizationPercent\x124\n" +
+	"\x16memory_utilization_raw\x18\x03 \x01(\x01R\x14memoryUtilizationRaw\x12<\n" +
+	"\x1amemory_utilization_percent\x18\x04 \x01(\x02R\x18memoryUtilizationPercent\"\xb9\x01\n" +
 	"\rStartResponse\x12\x1f\n" +
 	"\vinstance_id\x18\x01 \x01(\tR\n" +
 	"instanceId\x120\n" +
@@ -696,12 +714,13 @@ const file_worker_worker_proto_rawDesc = "" +
 	"\rEVENT_RUNNING\x10\x06*;\n" +
 	"\x06Status\x12\x1e\n" +
 	"\x1aSTATUS_SUCCESS_UNSPECIFIED\x10\x00\x12\x11\n" +
-	"\rSTATUS_FAILED\x10\x012\xa7\x02\n" +
+	"\rSTATUS_FAILED\x10\x012\xe9\x02\n" +
 	"\x06Worker\x124\n" +
 	"\x05Start\x12\x14.worker.StartRequest\x1a\x15.worker.StartResponse\x121\n" +
 	"\x04Stop\x12\x13.worker.StopRequest\x1a\x14.worker.StopResponse\x127\n" +
 	"\x06Status\x12\x15.worker.StatusRequest\x1a\x14.worker.StatusUpdate0\x01\x128\n" +
-	"\aMetrics\x12\x16.worker.MetricsRequest\x1a\x15.worker.MetricsUpdate\x12A\n" +
+	"\aMetrics\x12\x16.worker.MetricsRequest\x1a\x15.worker.MetricsUpdate\x12@\n" +
+	"\rMetricsStream\x12\x16.worker.MetricsRequest\x1a\x15.worker.MetricsUpdate0\x01\x12A\n" +
 	"\vSignalReady\x12\x1a.worker.SignalReadyRequest\x1a\x16.google.protobuf.EmptyB/Z-github.com/3s-rg-codes/HyperFaaS/proto/workerb\x06proto3"
 
 var (
@@ -743,14 +762,16 @@ var file_worker_worker_proto_depIdxs = []int32{
 	9,  // 5: worker.Worker.Stop:input_type -> worker.StopRequest
 	4,  // 6: worker.Worker.Status:input_type -> worker.StatusRequest
 	5,  // 7: worker.Worker.Metrics:input_type -> worker.MetricsRequest
-	11, // 8: worker.Worker.SignalReady:input_type -> worker.SignalReadyRequest
-	7,  // 9: worker.Worker.Start:output_type -> worker.StartResponse
-	10, // 10: worker.Worker.Stop:output_type -> worker.StopResponse
-	3,  // 11: worker.Worker.Status:output_type -> worker.StatusUpdate
-	6,  // 12: worker.Worker.Metrics:output_type -> worker.MetricsUpdate
-	13, // 13: worker.Worker.SignalReady:output_type -> google.protobuf.Empty
-	9,  // [9:14] is the sub-list for method output_type
-	4,  // [4:9] is the sub-list for method input_type
+	5,  // 8: worker.Worker.MetricsStream:input_type -> worker.MetricsRequest
+	11, // 9: worker.Worker.SignalReady:input_type -> worker.SignalReadyRequest
+	7,  // 10: worker.Worker.Start:output_type -> worker.StartResponse
+	10, // 11: worker.Worker.Stop:output_type -> worker.StopResponse
+	3,  // 12: worker.Worker.Status:output_type -> worker.StatusUpdate
+	6,  // 13: worker.Worker.Metrics:output_type -> worker.MetricsUpdate
+	6,  // 14: worker.Worker.MetricsStream:output_type -> worker.MetricsUpdate
+	13, // 15: worker.Worker.SignalReady:output_type -> google.protobuf.Empty
+	10, // [10:16] is the sub-list for method output_type
+	4,  // [4:10] is the sub-list for method input_type
 	4,  // [4:4] is the sub-list for extension type_name
 	4,  // [4:4] is the sub-list for extension extendee
 	0,  // [0:4] is the sub-list for field type_name

--- a/proto/worker/worker.proto
+++ b/proto/worker/worker.proto
@@ -45,8 +45,10 @@ message MetricsRequest {
 }
 
 message MetricsUpdate{
-  double used_ram_percent = 1;
-  repeated double cpu_percent_percpus = 2;
+  double cpu_utilization_raw = 1;
+  float cpu_utilization_percent = 2;
+  double memory_utilization_raw = 3;
+  float memory_utilization_percent = 4;
 }
 
 message StartResponse {
@@ -84,6 +86,8 @@ service Worker {
   rpc Status (StatusRequest) returns (stream StatusUpdate);
   // Returns resource usage metrics.
   rpc Metrics (MetricsRequest) returns (MetricsUpdate);
+  // Streams resource usage metrics.
+  rpc MetricsStream (MetricsRequest) returns (stream MetricsUpdate);
   // Signal that the instance is ready to serve requests. 
   // Instances must call this endpoint upon startup.
   rpc SignalReady (SignalReadyRequest) returns (google.protobuf.Empty);

--- a/proto/worker/worker_grpc.pb.go
+++ b/proto/worker/worker_grpc.pb.go
@@ -20,11 +20,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Worker_Start_FullMethodName       = "/worker.Worker/Start"
-	Worker_Stop_FullMethodName        = "/worker.Worker/Stop"
-	Worker_Status_FullMethodName      = "/worker.Worker/Status"
-	Worker_Metrics_FullMethodName     = "/worker.Worker/Metrics"
-	Worker_SignalReady_FullMethodName = "/worker.Worker/SignalReady"
+	Worker_Start_FullMethodName         = "/worker.Worker/Start"
+	Worker_Stop_FullMethodName          = "/worker.Worker/Stop"
+	Worker_Status_FullMethodName        = "/worker.Worker/Status"
+	Worker_Metrics_FullMethodName       = "/worker.Worker/Metrics"
+	Worker_MetricsStream_FullMethodName = "/worker.Worker/MetricsStream"
+	Worker_SignalReady_FullMethodName   = "/worker.Worker/SignalReady"
 )
 
 // WorkerClient is the client API for Worker service.
@@ -41,6 +42,8 @@ type WorkerClient interface {
 	Status(ctx context.Context, in *StatusRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[StatusUpdate], error)
 	// Returns resource usage metrics.
 	Metrics(ctx context.Context, in *MetricsRequest, opts ...grpc.CallOption) (*MetricsUpdate, error)
+	// Streams resource usage metrics.
+	MetricsStream(ctx context.Context, in *MetricsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[MetricsUpdate], error)
 	// Signal that the instance is ready to serve requests.
 	// Instances must call this endpoint upon startup.
 	SignalReady(ctx context.Context, in *SignalReadyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -103,6 +106,25 @@ func (c *workerClient) Metrics(ctx context.Context, in *MetricsRequest, opts ...
 	return out, nil
 }
 
+func (c *workerClient) MetricsStream(ctx context.Context, in *MetricsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[MetricsUpdate], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Worker_ServiceDesc.Streams[1], Worker_MetricsStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[MetricsRequest, MetricsUpdate]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Worker_MetricsStreamClient = grpc.ServerStreamingClient[MetricsUpdate]
+
 func (c *workerClient) SignalReady(ctx context.Context, in *SignalReadyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
@@ -127,6 +149,8 @@ type WorkerServer interface {
 	Status(*StatusRequest, grpc.ServerStreamingServer[StatusUpdate]) error
 	// Returns resource usage metrics.
 	Metrics(context.Context, *MetricsRequest) (*MetricsUpdate, error)
+	// Streams resource usage metrics.
+	MetricsStream(*MetricsRequest, grpc.ServerStreamingServer[MetricsUpdate]) error
 	// Signal that the instance is ready to serve requests.
 	// Instances must call this endpoint upon startup.
 	SignalReady(context.Context, *SignalReadyRequest) (*emptypb.Empty, error)
@@ -151,6 +175,9 @@ func (UnimplementedWorkerServer) Status(*StatusRequest, grpc.ServerStreamingServ
 }
 func (UnimplementedWorkerServer) Metrics(context.Context, *MetricsRequest) (*MetricsUpdate, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Metrics not implemented")
+}
+func (UnimplementedWorkerServer) MetricsStream(*MetricsRequest, grpc.ServerStreamingServer[MetricsUpdate]) error {
+	return status.Errorf(codes.Unimplemented, "method MetricsStream not implemented")
 }
 func (UnimplementedWorkerServer) SignalReady(context.Context, *SignalReadyRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SignalReady not implemented")
@@ -241,6 +268,17 @@ func _Worker_Metrics_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Worker_MetricsStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(MetricsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(WorkerServer).MetricsStream(m, &grpc.GenericServerStream[MetricsRequest, MetricsUpdate]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Worker_MetricsStreamServer = grpc.ServerStreamingServer[MetricsUpdate]
+
 func _Worker_SignalReady_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SignalReadyRequest)
 	if err := dec(in); err != nil {
@@ -287,6 +325,11 @@ var Worker_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "Status",
 			Handler:       _Worker_Status_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "MetricsStream",
+			Handler:       _Worker_MetricsStream_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/test/call.go
+++ b/test/call.go
@@ -65,7 +65,8 @@ func testCallGeneric[Req any, Resp any](t *testing.T,
 		if shouldFail {
 			return err
 		}
-		t.Errorf("Call failed: %v", err)
+		//t.Errorf("Call failed: %v", err)
+		t.Error()
 		return err
 	}
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -69,6 +69,7 @@ func TestCallRequest(t *testing.T) {
 
 	for _, d := range data {
 		t.Run("Concurrent Calls", func(t *testing.T) {
+			//t.Skip("Skipping concurrent calls test")
 			functionId := createFunctionMetadata(d.ImageTag)
 			t.Log("Sending Concurrent Calls")
 


### PR DESCRIPTION
Summary
- Add worker-side resource metrics collection and streaming, including aggregation across the worker container and its instances.
- Expose configurable CPU/memory budgets via env vars so aggregated usage can be expressed as percentages in docker-compose simulations.
- Now leaf consumes worker resource metrics streams (not yet used for scheduling).

Notes
- Workers sum per-container stats (instances + worker) into an aggregated view and publish it via the Metrics/MetricsStream RPCs.
- Budgets (WORKER_BUDGET_CPU, WORKER_BUDGET_MEMORY) are symbolic for now; workers can still schedule beyond budget. This enables realistic load‑balancing experiments in local compose without enforcing hard limits.
- Introduces a ResourceManager in the worker to create the aggregated metrics, but it can be considered ground work for a future real resource management, where we can guard against creating new instances when we don't have resource capacity.